### PR TITLE
Import ExceptionUnwrapping via XUnit.

### DIFF
--- a/src/shared-distributed-code.jl
+++ b/src/shared-distributed-code.jl
@@ -2,9 +2,8 @@ module SharedDistributedCode
 
 using Distributed
 using Test
-using ExceptionUnwrapping: has_wrapped_exception
 using XUnit
-using XUnit: create_deep_copy
+using XUnit: create_deep_copy, has_wrapped_exception
 
 function do_work(jobs, results) # define work function everywhere
     try


### PR DESCRIPTION
Otherwise I get:

```
ERROR: LoadError: TaskFailedException

    nested task error: LoadError: On worker 2:
    LoadError: UndefVarError: ExceptionUnwrapping not defined
    Stacktrace:
     [1] eval
       @ ./boot.jl:360 [inlined]
     [2] include_string
       @ ./loading.jl:1090
     [3] include_string
       @ ./loading.jl:1100
     [4] top-level scope
       @ none:1
     [5] eval
       @ ./boot.jl:360
     [6] #103
       @ ~/Julia/src/julia/build/release/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:274
     [7] run_work_thunk
       @ ~/Julia/src/julia/build/release/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:63
     [8] run_work_thunk
       @ ~/Julia/src/julia/build/release/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:72
     [9] #96
       @ ./task.jl:406
    in expression starting at shared-distributed-code.jl:1
```

(unless I explicitly add ExceptionUnwrapping as a test dep, which isn't very nice)