### PR TITLE
Extension XUnit

### DIFF
--- a/src/XUnit.jl
+++ b/src/XUnit.jl
@@ -38,7 +38,7 @@ mutable struct _AsyncTestCase{ASYNC_TEST_SUITE}
     modify_lock::ReentrantLock
 end
 
-struct AsyncTestSuite
+mutable struct AsyncTestSuite
     testset_report::AbstractTestSet
     parent_testset::Option{Union{_AsyncTestCase{AsyncTestSuite},AsyncTestSuite}}
     before_each_hook::Function

--- a/src/test-metrics.jl
+++ b/src/test-metrics.jl
@@ -111,6 +111,9 @@ Combines the merics results from a `sub` into its `parent`
 """
 function combine_test_metrics(parent, sub)
     # nothing to do
+   # we should always return the new parent, in case we've replaced the parent.
+   # Note: we can replace the parent only if it's a subtype of `TestMetrics`
+    return parent
 end
 
 function combine_test_metrics(parent::AsyncTestSuite, sub::AsyncTestSuite)

--- a/src/test-metrics.jl
+++ b/src/test-metrics.jl
@@ -38,11 +38,11 @@ function gather_test_metrics(t::AsyncTestSuite)
     if !t.disabled
         for sub_testset in t.sub_testsets
             gather_test_metrics(sub_testset)
-            combine_test_metrics(t, sub_testset)
+            t = combine_test_metrics(t, sub_testset)
         end
 
         for sub_testcase in t.sub_testcases
-            combine_test_metrics(t, sub_testcase)
+            t = combine_test_metrics(t, sub_testcase)
         end
     end
 end
@@ -114,11 +114,13 @@ function combine_test_metrics(parent, sub)
 end
 
 function combine_test_metrics(parent::AsyncTestSuite, sub::AsyncTestSuite)
-    combine_test_metrics(parent.metrics, sub.metrics)
+    parent.metrics = combine_test_metrics(parent.metrics, sub.metrics)
+    return parent
 end
 
 function combine_test_metrics(parent::AsyncTestSuite, sub::AsyncTestCase)
-    combine_test_metrics(parent.metrics, sub.metrics)
+    parent.metrics = combine_test_metrics(parent.metrics, sub.metrics)
+    return parent
 end
 
 function combine_test_metrics(parent::DefaultTestMetrics, sub::DefaultTestMetrics)
@@ -136,7 +138,7 @@ function combine_test_metrics(parent::DefaultTestMetrics, sub::DefaultTestMetric
         parent.gcstats.pause + sub.gcstats.pause,
         parent.gcstats.full_sweep + sub.gcstats.full_sweep,
     )
-    nothing
+    return parent
 end
 
 """
@@ -159,9 +161,9 @@ function create_test_metrics(
 end
 
 function create_test_metrics(
-    parent_testset::Option{AsyncTestSuiteOrTestCase}, ::T
+    parent_testset::Option{AsyncTestSuiteOrTestCase}, instance::T
 ) where T <: TestMetrics
-    return create_test_metrics(parent_testset, T)
+    return create_new_measure_instance(instance; report_metric=true)
 end
 
 function create_test_metrics(

--- a/src/test-metrics.jl
+++ b/src/test-metrics.jl
@@ -38,11 +38,15 @@ function gather_test_metrics(t::AsyncTestSuite)
     if !t.disabled
         for sub_testset in t.sub_testsets
             gather_test_metrics(sub_testset)
-            t = combine_test_metrics(t, sub_testset)
+            sub_t = combine_test_metrics(t, sub_testset)
+             # we should only mutate the current t inside combine_test_metrics 
+            @assert t === sub_t
         end
 
         for sub_testcase in t.sub_testcases
-            t = combine_test_metrics(t, sub_testcase)
+            sub_t = combine_test_metrics(t, sub_testcase)
+             # we should only mutate the current t inside combine_test_metrics 
+            @assert t === sub_t
         end
     end
 end

--- a/src/test-metrics.jl
+++ b/src/test-metrics.jl
@@ -111,8 +111,8 @@ Combines the merics results from a `sub` into its `parent`
 """
 function combine_test_metrics(parent, sub)
     # nothing to do
-   # we should always return the new parent, in case we've replaced the parent.
-   # Note: we can replace the parent only if it's a subtype of `TestMetrics`
+    # we should always return the new parent, in case we've replaced the parent.
+    # Note: we can replace the parent only if it's a subtype of `TestMetrics`
     return parent
 end
 


### PR DESCRIPTION
This PR extends `XUnit` in the following ways:

- Extend the function `combine_test_metrics ` to return the `parent` that has been modified internally.
- Extend the function `create_test_metrics ` to allow more flexible instantion of `test_metrics`.