### PR TITLE
Bump version number to 1.1.4.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "XUnit"
 uuid = "3e3c03f2-1a94-11e9-2981-050a4ca824ab"
 authors = ["Mohammad Dashti <mdashti@gmail.com>"]
-version = "1.1.3"
+version = "1.1.4"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"


### PR DESCRIPTION
Bump version number to 1.1.4 ahead of tagging a release that should work on Julia 1.7.