### PR TITLE
Fix Test.Pass serialization to ignore unsafe `.data` field.

### DIFF
--- a/src/test-runners.jl
+++ b/src/test-runners.jl
@@ -716,6 +716,10 @@ function convert_results_to_be_transferrable(res::Pass)
         # on other processes (e.g., the master process that consolidates the results)
         # The stack-trace is converted to string here.
         return Pass(:test_throws, nothing, nothing, string(res.value))
+    else
+        # Ignore the `res.data` field for Test.Pass, since it can contain values interpolated
+        # into the Expr, which may only be valid in this process.
+        return Pass(res.test_type, res.orig_expr, nothing, res.value, res.source, res.message_only)
     end
     return res
 end


### PR DESCRIPTION
The `result.data` field is not safe to be serialized across the wire.

JuliaLang/julia's own distributed test runner filters them out, here: https://github.com/JuliaLang/julia/blob/b9b0bcf7010abb0840e6ef8949b67ca70e2327cf/test/runtests.jl#L390-L398

This adds the same filtering to the XUnit test serialization.

Note that Julia's tests do even more filtering than this. For the passing tests, they just return `Test.Pass(:test, nothing, nothing, nothing, LineNumberNode(@__LINE__, @__FILE__)))`. We could consider doing the same, since right now these numbers just get summed up anyway when displaying the tests, since we currently don't use the JUnit test output.

But i'll leave this change as minimal as possible for now.


### Review Guidelines
This probably needs a unit test, but since we're very close to dropping XUnit entirely, i'm considering not doing that.
Maybe you can add one if you want to, Babis?