### PR TITLE
Set an ENV var to allow identifying `runtests` call

### DIFF
--- a/src/XUnit.jl
+++ b/src/XUnit.jl
@@ -811,8 +811,10 @@ function runtests_return_state(fun::Function, depth::Int64=typemax(Int64), args.
 end
 
 function runtests(fun::Function, depth::Int64=typemax(Int64), args...)
-    (fn_res, state) = runtests_return_state(fun, depth, args...)
-    return fn_res
+    withenv("XUNIT_RUNTESTS" => "true") do
+        (fn_res, state) = runtests_return_state(fun, depth, args...)
+        return fn_res
+    end
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,4 +21,10 @@ if VERSION.major == 1 && VERSION.minor == 5
 end
 include("regex-tests.jl")
 
+@testset "ENV variable" begin
+    @test  !haskey(ENV, "XUNIT_RUNTESTS")
+    XUnit.runtests("test_env_variable.jl")
+    @test  !haskey(ENV, "XUNIT_RUNTESTS")
+end
+
 end

--- a/test/test_env_variable.jl
+++ b/test/test_env_variable.jl
@@ -1,0 +1,2 @@
+using Test
+@test "true" == get(ENV, "XUNIT_RUNTESTS", missing)


### PR DESCRIPTION
- So that one can check in the `include`d file if it is being `include`d by `XUnit.runtests`